### PR TITLE
fix: improve phone validation for leading zero inputs

### DIFF
--- a/src/services/firebaseAuthService.ts
+++ b/src/services/firebaseAuthService.ts
@@ -85,19 +85,41 @@ class FirebaseAuthService {
     
     // Check for Indian phone number patterns
     if (digits.length === 10 && digits.match(/^[6-9]\d{9}$/)) {
-      return { 
-        isValid: true, 
-        formatted: `+91${digits}` 
+      // Standard 10 digit mobile number
+      return {
+        isValid: true,
+        formatted: `+91${digits}`
       };
-    } else if (digits.length === 12 && digits.startsWith('91') && digits.substring(2).match(/^[6-9]\d{9}$/)) {
-      return { 
-        isValid: true, 
-        formatted: `+${digits}` 
+    } else if (
+      digits.length === 11 &&
+      digits.startsWith('0') &&
+      digits.substring(1).match(/^[6-9]\d{9}$/)
+    ) {
+      // Number with leading zero (0XXXXXXXXXX)
+      return {
+        isValid: true,
+        formatted: `+91${digits.substring(1)}`
       };
-    } else if (digits.length === 13 && digits.startsWith('91') && digits.substring(3).match(/^[6-9]\d{9}$/)) {
-      return { 
-        isValid: true, 
-        formatted: `+${digits.substring(1)}` 
+    } else if (
+      digits.length === 12 &&
+      digits.startsWith('91') &&
+      digits.substring(2).match(/^[6-9]\d{9}$/)
+    ) {
+      // Number with country code (91XXXXXXXXXX)
+      return {
+        isValid: true,
+        formatted: `+${digits}`
+      };
+    } else if (
+      digits.length === 13 &&
+      digits.startsWith('0') &&
+      digits.substring(1, 3) === '91' &&
+      digits.substring(3).match(/^[6-9]\d{9}$/)
+    ) {
+      // Number with leading zero and country code (0 91XXXXXXXXXX)
+      return {
+        isValid: true,
+        formatted: `+${digits.substring(1)}`
       };
     }
 


### PR DESCRIPTION
## Summary
- handle Indian phone numbers with a leading zero
- correct validation logic for numbers prefixed with 0 and country code

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c0895a9f4832fa8d4cbe84c4e76d0