### PR TITLE
feat: add flutter voice assistant widget

### DIFF
--- a/flutter_voice_assistant/lib/services/ai_service.dart
+++ b/flutter_voice_assistant/lib/services/ai_service.dart
@@ -1,0 +1,34 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+/// A simple wrapper around text-generation APIs such as OpenAI or AI4Bharat.
+class AiService {
+  /// API key for authentication.
+  final String apiKey;
+
+  /// Endpoint for text-generation requests.
+  final String baseUrl;
+
+  AiService({required this.apiKey, required this.baseUrl});
+
+  /// Sends [prompt] to the configured API and returns the generated text.
+  Future<String> generateText(String prompt) async {
+    final response = await http.post(
+      Uri.parse(baseUrl),
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $apiKey',
+      },
+      body: jsonEncode({'prompt': prompt}),
+    );
+
+    if (response.statusCode == 200) {
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      // Both OpenAI and AI4Bharat return the generated text in `text` or `data`.
+      return data['text'] ?? data['data']?['text'] ?? '';
+    } else {
+      throw Exception('Failed to generate text: ${response.statusCode}');
+    }
+  }
+}

--- a/flutter_voice_assistant/lib/widgets/voice_assistant_widget.dart
+++ b/flutter_voice_assistant/lib/widgets/voice_assistant_widget.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:speech_to_text/speech_to_text.dart' as stt;
+import 'package:flutter_tts/flutter_tts.dart';
+
+import '../services/ai_service.dart';
+
+/// A reusable widget providing voice interaction with AI text generation.
+class VoiceAssistantWidget extends StatefulWidget {
+  final AiService aiService;
+
+  const VoiceAssistantWidget({super.key, required this.aiService});
+
+  @override
+  State<VoiceAssistantWidget> createState() => _VoiceAssistantWidgetState();
+}
+
+class _VoiceAssistantWidgetState extends State<VoiceAssistantWidget> {
+  final stt.SpeechToText _speech = stt.SpeechToText();
+  final FlutterTts _tts = FlutterTts();
+  final List<_Message> _messages = [];
+  bool _isListening = false;
+
+  Future<void> _startListening() async {
+    final available = await _speech.initialize();
+    if (available) {
+      setState(() => _isListening = true);
+      _speech.listen(onResult: (result) {
+        if (result.finalResult) {
+          _handleUserText(result.recognizedWords);
+        }
+      });
+    }
+  }
+
+  Future<void> _stopListening() async {
+    await _speech.stop();
+    setState(() => _isListening = false);
+  }
+
+  Future<void> _handleUserText(String text) async {
+    setState(() {
+      _messages.add(_Message(text: text, isUser: true));
+    });
+    try {
+      final reply = await widget.aiService.generateText(text);
+      setState(() {
+        _messages.add(_Message(text: reply, isUser: false));
+      });
+      await _tts.speak(reply);
+    } catch (e) {
+      setState(() {
+        _messages.add(_Message(text: 'Error: $e', isUser: false));
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _speech.stop();
+    _tts.stop();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Expanded(
+          child: ListView.builder(
+            itemCount: _messages.length,
+            itemBuilder: (context, index) {
+              final msg = _messages[index];
+              return Align(
+                alignment:
+                    msg.isUser ? Alignment.centerRight : Alignment.centerLeft,
+                child: Container(
+                  margin:
+                      const EdgeInsets.symmetric(vertical: 4.0, horizontal: 8.0),
+                  padding: const EdgeInsets.all(12.0),
+                  decoration: BoxDecoration(
+                    color: msg.isUser
+                        ? Colors.blueAccent
+                        : Colors.grey.shade300,
+                    borderRadius: BorderRadius.circular(12.0),
+                  ),
+                  child: Text(
+                    msg.text,
+                    style: TextStyle(
+                      color: msg.isUser ? Colors.white : Colors.black87,
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+        const SizedBox(height: 8),
+        FloatingActionButton(
+          onPressed: _isListening ? _stopListening : _startListening,
+          child: Icon(_isListening ? Icons.stop : Icons.mic),
+        ),
+      ],
+    );
+  }
+}
+
+class _Message {
+  final String text;
+  final bool isUser;
+
+  _Message({required this.text, required this.isUser});
+}

--- a/flutter_voice_assistant/pubspec.yaml
+++ b/flutter_voice_assistant/pubspec.yaml
@@ -1,0 +1,20 @@
+name: flutter_voice_assistant
+description: Voice assistant module for EasyMedPro using speech_to_text and flutter_tts.
+version: 0.1.0
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  speech_to_text: ^6.5.0
+  flutter_tts: ^3.6.3
+  http: ^0.13.6
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add Flutter voice assistant module with speech-to-text and text-to-speech
- wrap text generation APIs in a reusable AiService
- provide VoiceAssistantWidget to capture voice, call AI, and render chat UI

## Testing
- `dart format flutter_voice_assistant/lib/services/ai_service.dart flutter_voice_assistant/lib/widgets/voice_assistant_widget.dart flutter_voice_assistant/pubspec.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ddc680024832f86203c783a19735f