### PR TITLE
feat: add flutter dashboards

### DIFF
--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -1,0 +1,6 @@
+class User {
+  final String userType;
+  final String name;
+
+  const User({required this.userType, required this.name});
+}

--- a/lib/screens/admin_dashboard.dart
+++ b/lib/screens/admin_dashboard.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import '../models/user.dart';
+
+class AdminDashboard extends StatelessWidget {
+  final User user;
+  const AdminDashboard({super.key, required this.user});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Admin Dashboard')),
+      body: Center(child: Text('Welcome, ${user.name}')),
+    );
+  }
+}

--- a/lib/screens/asha_dashboard.dart
+++ b/lib/screens/asha_dashboard.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import '../models/user.dart';
+
+class AshaDashboard extends StatelessWidget {
+  final User user;
+  const AshaDashboard({super.key, required this.user});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('ASHA Dashboard')),
+      body: Center(child: Text('Welcome, ${user.name}')),
+    );
+  }
+}

--- a/lib/screens/asha_dashboard_enhanced.dart
+++ b/lib/screens/asha_dashboard_enhanced.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import '../models/user.dart';
+
+class AshaDashboardEnhanced extends StatelessWidget {
+  final User user;
+  const AshaDashboardEnhanced({super.key, required this.user});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('ASHA Dashboard+')),
+      body: Center(child: Text('Enhanced features for ${user.name}')),
+    );
+  }
+}

--- a/lib/screens/dashboard_router.dart
+++ b/lib/screens/dashboard_router.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import '../models/user.dart';
+import 'admin_dashboard.dart';
+import 'doctor_dashboard.dart';
+import 'patient_dashboard.dart';
+import 'patient_dashboard_enhanced.dart';
+import 'asha_dashboard.dart';
+import 'asha_dashboard_enhanced.dart';
+import 'otp_diagnostic_panel.dart';
+
+void navigateToDashboard(BuildContext context, User user, {bool enhanced = false}) {
+  Widget screen;
+  switch (user.userType) {
+    case 'admin':
+      screen = AdminDashboard(user: user);
+      break;
+    case 'doctor':
+      screen = DoctorDashboard(user: user);
+      break;
+    case 'asha':
+      screen = enhanced ? AshaDashboardEnhanced(user: user) : AshaDashboard(user: user);
+      break;
+    case 'patient':
+      screen = enhanced ? PatientDashboardEnhanced(user: user) : PatientDashboard(user: user);
+      break;
+    case 'otp':
+      screen = const OtpDiagnosticPanel();
+      break;
+    default:
+      screen = PatientDashboard(user: user);
+  }
+
+  Navigator.pushReplacement(
+    context,
+    MaterialPageRoute(builder: (_) => screen),
+  );
+}

--- a/lib/screens/doctor_dashboard.dart
+++ b/lib/screens/doctor_dashboard.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import '../models/user.dart';
+
+class DoctorDashboard extends StatelessWidget {
+  final User user;
+  const DoctorDashboard({super.key, required this.user});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Doctor Dashboard')),
+      body: Center(child: Text('Welcome, ${user.name}')),
+    );
+  }
+}

--- a/lib/screens/otp_diagnostic_panel.dart
+++ b/lib/screens/otp_diagnostic_panel.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class OtpDiagnosticPanel extends StatelessWidget {
+  const OtpDiagnosticPanel({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('OTP Diagnostic Panel')),
+      body: const Center(child: Text('OTP diagnostics go here')),
+    );
+  }
+}

--- a/lib/screens/patient_dashboard.dart
+++ b/lib/screens/patient_dashboard.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import '../models/user.dart';
+
+class PatientDashboard extends StatefulWidget {
+  final User user;
+  const PatientDashboard({super.key, required this.user});
+
+  @override
+  State<PatientDashboard> createState() => _PatientDashboardState();
+}
+
+class _PatientDashboardState extends State<PatientDashboard> {
+  int index = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Welcome, ${widget.user.name}')),
+      body: Center(child: Text('Tab $index')),
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: index,
+        onTap: (i) => setState(() => index = i),
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.home), label: 'HOME'),
+          BottomNavigationBarItem(icon: Icon(Icons.smart_toy), label: 'AI'),
+          BottomNavigationBarItem(icon: Icon(Icons.calendar_today), label: 'APPOINTMENTS'),
+          BottomNavigationBarItem(icon: Icon(Icons.monitor_heart), label: 'HEALTH'),
+          BottomNavigationBarItem(icon: Icon(Icons.person), label: 'PROFILE'),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/patient_dashboard_enhanced.dart
+++ b/lib/screens/patient_dashboard_enhanced.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import '../models/user.dart';
+
+class PatientDashboardEnhanced extends StatelessWidget {
+  final User user;
+  const PatientDashboardEnhanced({super.key, required this.user});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Patient Dashboard+')),
+      body: Center(child: Text('Enhanced features for ${user.name}')),
+    );
+  }
+}

--- a/lib/services/user_service.dart
+++ b/lib/services/user_service.dart
@@ -1,0 +1,9 @@
+import '../models/user.dart';
+
+class UserService {
+  // Placeholder for fetching user data; in real app reuse existing services.
+  Future<User> fetchCurrentUser() async {
+    // TODO: integrate with real data source
+    return const User(userType: 'patient', name: 'Demo User');
+  }
+}


### PR DESCRIPTION
## Summary
- add basic user model and service for Flutter app
- implement Flutter dashboard screens for admin, doctor, ASHA, patient, and OTP diagnostic panel
- add router for role-based navigation using Navigator.pushReplacement

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ddc6bb174832f87970a29ff059bf9