### PR TITLE
feat: add initial Flutter mobile project

### DIFF
--- a/easymedpro_mobile/.gitignore
+++ b/easymedpro_mobile/.gitignore
@@ -1,0 +1,7 @@
+# Flutter/Dart/Pub related
+.dart_tool/
+.packages
+.pub/
+build/
+android/app/build/
+ios/Runner/build/

--- a/easymedpro_mobile/android/app/google-services.json
+++ b/easymedpro_mobile/android/app/google-services.json
@@ -1,0 +1,6 @@
+{
+  "project_info": {
+    "project_number": "YOUR_PROJECT_NUMBER",
+    "project_id": "YOUR_PROJECT_ID"
+  }
+}

--- a/easymedpro_mobile/ios/Runner/GoogleService-Info.plist
+++ b/easymedpro_mobile/ios/Runner/GoogleService-Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PROJECT_ID</key>
+  <string>YOUR_PROJECT_ID</string>
+</dict>
+</plist>

--- a/easymedpro_mobile/lib/main.dart
+++ b/easymedpro_mobile/lib/main.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'EasyMedPro',
+      localizationsDelegates: const [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [
+        Locale('en'),
+      ],
+      home: const Scaffold(
+        body: Center(child: Text('Hello World')),
+      ),
+    );
+  }
+}

--- a/easymedpro_mobile/pubspec.yaml
+++ b/easymedpro_mobile/pubspec.yaml
@@ -1,0 +1,29 @@
+name: easymedpro_mobile
+description: A new Flutter project for EasyMedPro mobile.
+publish_to: "none"
+version: 1.0.0+1
+
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  firebase_core: any
+  firebase_auth: any
+  http: any
+  intl: any
+  provider: any
+  flutter_tts: any
+  speech_to_text: any
+  flutter_localizations:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: any
+
+flutter:
+  uses-material-design: true
+  generate: true


### PR DESCRIPTION
## Summary
- scaffold `easymedpro_mobile` Flutter project
- add core packages and localization support
- include placeholder Firebase configs for Android and iOS

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ddc734f64832fb525616643b733e9