### PR TITLE
Add mobile React Native scaffold with TypeScript and navigation

### DIFF
--- a/mobile/.env.development.example
+++ b/mobile/.env.development.example
@@ -1,0 +1,1 @@
+API_URL=http://localhost:3000

--- a/mobile/.env.production.example
+++ b/mobile/.env.production.example
@@ -1,0 +1,1 @@
+API_URL=https://api.example.com

--- a/mobile/.eslintrc.js
+++ b/mobile/.eslintrc.js
@@ -1,0 +1,11 @@
+module.exports = {
+  root: true,
+  extends: ['@react-native-community', 'eslint:recommended'],
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  env: {
+    node: true,
+    es6: true,
+  },
+  rules: {},
+};

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import RootNavigator from './src/navigation/RootNavigator';
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <RootNavigator />
+    </NavigationContainer>
+  );
+}

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -1,0 +1,11 @@
+import { ConfigContext, ExpoConfig } from 'expo/config';
+import 'dotenv/config';
+
+export default ({ config }: ConfigContext): ExpoConfig => ({
+  ...config,
+  name: 'EasyMedPro Mobile',
+  slug: 'easymedpro-mobile',
+  extra: {
+    apiUrl: process.env.API_URL || 'http://localhost:3000',
+  },
+});

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "easymedpro-mobile",
+  "version": "1.0.0",
+  "private": true,
+  "main": "expo-router/entry",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web",
+    "lint": "eslint .",
+    "test": "jest"
+  },
+  "dependencies": {
+    "expo": "^49.0.0",
+    "react": "18.2.0",
+    "react-native": "0.72.0",
+    "react-native-web": "~0.19.6",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/native-stack": "^6.9.12"
+  },
+  "devDependencies": {
+    "@react-native-community/eslint-config": "^3.2.0",
+    "@types/jest": "^29.5.2",
+    "@types/react": "~18.2.14",
+    "@types/react-native": "~0.72.3",
+    "@typescript-eslint/eslint-plugin": "^5.62.0",
+    "@typescript-eslint/parser": "^5.62.0",
+    "eslint": "^8.50.0",
+    "jest": "^29.7.0",
+    "typescript": "^5.2.2"
+  }
+}

--- a/mobile/src/config/env.ts
+++ b/mobile/src/config/env.ts
@@ -1,0 +1,4 @@
+import Constants from 'expo-constants';
+
+export const API_URL: string =
+  (Constants.expoConfig?.extra?.apiUrl as string) || 'http://localhost:3000';

--- a/mobile/src/navigation/RootNavigator.tsx
+++ b/mobile/src/navigation/RootNavigator.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+const Stack = createNativeStackNavigator();
+
+function HomeScreen() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Home Screen</Text>
+    </View>
+  );
+}
+
+export default function RootNavigator() {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen name="Home" component={HomeScreen} />
+    </Stack.Navigator>
+  );
+}

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "jsx": "react-native",
+    "moduleResolution": "node",
+    "strict": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold Expo-based mobile project with TypeScript and React Navigation
- configure ESLint and sample environment setup for API endpoints

## Testing
- `npm install` *(fails: 403 Forbidden from registry)*
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @react-native-community config)*

------
https://chatgpt.com/codex/tasks/task_e_689e13217524832f8bef56217bf5c77d