### PR TITLE
Add Jest tests and Fastlane build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build and Distribute
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+      - name: Install Fastlane
+        run: gem install fastlane
+      - name: Build and upload iOS to TestFlight
+        run: fastlane ios testflight
+        env:
+          APP_STORE_CONNECT_API_KEY_PATH: ${{ secrets.APP_STORE_CONNECT_API_KEY_PATH }}
+          APP_STORE_CONNECT_API_ISSUER: ${{ secrets.APP_STORE_CONNECT_API_ISSUER }}
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+      - name: Build and upload Android to internal testing
+        run: fastlane android deploy_internal
+        env:
+          GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,0 +1,2 @@
+app_identifier("com.easymedpro.app")
+apple_id("apple@example.com")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,25 @@
+default_platform(:ios)
+
+platform :ios do
+  desc 'Build iOS app and upload to TestFlight'
+  lane :testflight do
+    sh('npm run build:ios')
+    upload_to_testflight(
+      api_key_path: ENV['APP_STORE_CONNECT_API_KEY_PATH'],
+      api_issuer: ENV['APP_STORE_CONNECT_API_ISSUER'],
+      api_key_id: ENV['APP_STORE_CONNECT_API_KEY_ID']
+    )
+  end
+end
+
+platform :android do
+  desc 'Build Android app and upload to internal testing'
+  lane :deploy_internal do
+    sh('npm run build:android')
+    upload_to_play_store(
+      track: 'internal',
+      json_key_data: ENV['GOOGLE_PLAY_JSON_KEY'],
+      aab: 'android/app/build/outputs/bundle/release/app-release.aab'
+    )
+  end
+end

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  transform: {
+    '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: './tsconfig.json' }]
+  }
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-native/extend-expect';

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "serve:firebase": "firebase serve --only hosting",
     "emulate:firebase": "firebase emulators:start",
     "lint": "echo 'No linting configured'",
-    "test": "echo 'No tests configured'"
+    "test": "jest"
   },
   "dependencies": {
     "@capacitor/android": "^7.4.2",
@@ -68,6 +68,13 @@
     "@types/jsonwebtoken": "^9.0.10",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
+    "@types/jest": "^29.5.5",
+    "@testing-library/jest-native": "^5.4.4",
+    "@testing-library/react-native": "^12.6.0",
+    "jest": "^29.7.0",
+    "react-native": "^0.73.6",
+    "react-test-renderer": "^18.2.0",
+    "ts-jest": "^29.1.1",
     "@typescript-eslint/eslint-plugin": "^7.2.0",
     "@typescript-eslint/parser": "^7.2.0",
     "@vercel/node": "^5.3.11",

--- a/src/components/HelloButton.tsx
+++ b/src/components/HelloButton.tsx
@@ -1,0 +1,14 @@
+import React, { useState } from 'react';
+import { View, Text, Pressable } from 'react-native';
+
+export default function HelloButton() {
+  const [count, setCount] = useState(0);
+  return (
+    <View>
+      <Pressable onPress={() => setCount(c => c + 1)}>
+        <Text>Hello</Text>
+      </Pressable>
+      <Text testID="count">{count}</Text>
+    </View>
+  );
+}

--- a/src/components/__tests__/HelloButton.test.tsx
+++ b/src/components/__tests__/HelloButton.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import HelloButton from '../HelloButton';
+
+describe('HelloButton', () => {
+  it('increments counter on press', () => {
+    const { getByText, getByTestId } = render(<HelloButton />);
+    fireEvent.press(getByText('Hello'));
+    expect(getByTestId('count')).toHaveTextContent('1');
+  });
+});

--- a/src/services/__tests__/authService.test.ts
+++ b/src/services/__tests__/authService.test.ts
@@ -1,0 +1,7 @@
+import authService from '../authService';
+
+describe('authService', () => {
+  it('returns API base URL', () => {
+    expect(authService.getApiBaseUrl()).toBe('/api');
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest with React Native Testing Library
- add example unit and component tests
- introduce Fastlane and GitHub Actions for automated mobile builds

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-native)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e13275078832fbdeb77e13966ce5b