### PR TITLE
Add web build stubs and Cordova variables file

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -2,8 +2,8 @@
 
 android {
   compileOptions {
-      sourceCompatibility JavaVersion.VERSION_17
-      targetCompatibility JavaVersion.VERSION_17
+      sourceCompatibility JavaVersion.VERSION_21
+      targetCompatibility JavaVersion.VERSION_21
   }
 }
 

--- a/android/cordova-variables.gradle
+++ b/android/cordova-variables.gradle
@@ -1,0 +1,2 @@
+// Placeholder for Cordova plugin variables required by Capacitor plugins.
+// Add plugin-specific variables here if needed.

--- a/src/stubs/expo-av.ts
+++ b/src/stubs/expo-av.ts
@@ -1,0 +1,7 @@
+export const Audio = {
+  Sound: class {
+    async loadAsync() {}
+    async playAsync() {}
+    unloadAsync() {}
+  }
+};

--- a/src/stubs/expo-camera.ts
+++ b/src/stubs/expo-camera.ts
@@ -1,0 +1,7 @@
+import React from 'react';
+export const Camera: React.FC<any> = ({ children, ...props }) => <div {...props}>{children}</div>;
+export enum CameraType {
+  back = 'back',
+  front = 'front'
+}
+export async function requestCameraPermissionsAsync() { return { status: 'granted' }; }

--- a/src/stubs/expo-file-system.ts
+++ b/src/stubs/expo-file-system.ts
@@ -1,0 +1,3 @@
+export async function writeAsStringAsync(_path: string, _data: string) {}
+export async function readAsStringAsync(_path: string) { return ''; }
+export const documentDirectory = '';

--- a/src/stubs/expo-media-library.ts
+++ b/src/stubs/expo-media-library.ts
@@ -1,0 +1,2 @@
+export async function saveToLibraryAsync(_asset: any) {}
+export async function requestPermissionsAsync() { return { status: 'granted' }; }

--- a/src/stubs/expo-speech.ts
+++ b/src/stubs/expo-speech.ts
@@ -1,0 +1,3 @@
+export function speak(_text: string, _options?: any) {
+  console.warn('Speech.speak is not implemented on web');
+}

--- a/src/stubs/react-native-ble-plx.ts
+++ b/src/stubs/react-native-ble-plx.ts
@@ -1,0 +1,16 @@
+export class BleManager {
+  startDeviceScan(_serviceUUIDs: string[] | null, _options: any, _listener: any) {
+    // Web stub: Bluetooth scanning not supported
+    console.warn('BleManager.startDeviceScan is not implemented on web');
+  }
+  stopDeviceScan() {
+    // Web stub: nothing to stop
+  }
+}
+
+// Export empty enums and types to satisfy imports
+export enum State {}
+export enum LogLevel {}
+export enum ConnectionPriority {}
+export enum ScanCallbackType {}
+export enum ScanMode {}

--- a/src/stubs/react-native-health.ts
+++ b/src/stubs/react-native-health.ts
@@ -1,0 +1,7 @@
+export const HealthKitPermissions: any = {};
+export default {
+  initHealthKit: (_options: any, callback: (err?: Error) => void) => {
+    console.warn('HealthKit is not available on web');
+    callback();
+  }
+};

--- a/src/stubs/react-native-voice.ts
+++ b/src/stubs/react-native-voice.ts
@@ -1,0 +1,12 @@
+export default {
+  onSpeechStart: null,
+  onSpeechEnd: null,
+  onSpeechResults: null,
+  start: async () => {
+    console.warn('Voice.start is not implemented on web');
+  },
+  stop: async () => {
+    console.warn('Voice.stop is not implemented on web');
+  },
+  removeAllListeners: () => {},
+};

--- a/src/stubs/react-native.ts
+++ b/src/stubs/react-native.ts
@@ -1,0 +1,28 @@
+import React from 'react';
+export const View: React.FC<any> = ({ children, ...props }) => <div {...props}>{children}</div>;
+export const Text: React.FC<any> = ({ children, ...props }) => <span {...props}>{children}</span>;
+export const Pressable: React.FC<any> = ({ children, onPress, ...props }) => (
+  <button onClick={onPress} {...props}>{children}</button>
+);
+export const TouchableOpacity = Pressable;
+export const Image: React.FC<any> = (props) => <img {...props} />;
+export const StyleSheet = { create: (styles: any) => styles };
+export const ActivityIndicator: React.FC<any> = () => <div>Loading...</div>;
+export const NativeModules: any = {};
+export const Platform = { OS: 'web' };
+export class NativeEventEmitter {
+  addListener() { return { remove() {} }; }
+  removeAllListeners() {}
+}
+export default {
+  View,
+  Text,
+  Pressable,
+  TouchableOpacity,
+  Image,
+  StyleSheet,
+  ActivityIndicator,
+  NativeModules,
+  Platform,
+  NativeEventEmitter,
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,15 @@ export default defineConfig({
       '@': resolve(__dirname, './src'),
       '@core': resolve(__dirname, './packages/core/src'),
       // Add this line to resolve React Native components on the web
-      'react-native': 'react-native-web',
+      'react-native': resolve(__dirname, './src/stubs/react-native.ts'),
+      'react-native-ble-plx': resolve(__dirname, './src/stubs/react-native-ble-plx.ts'),
+      '@react-native-voice/voice': resolve(__dirname, './src/stubs/react-native-voice.ts'),
+      'react-native-health': resolve(__dirname, './src/stubs/react-native-health.ts'),
+      'expo-av': resolve(__dirname, './src/stubs/expo-av.ts'),
+      'expo-camera': resolve(__dirname, './src/stubs/expo-camera.ts'),
+      'expo-file-system': resolve(__dirname, './src/stubs/expo-file-system.ts'),
+      'expo-media-library': resolve(__dirname, './src/stubs/expo-media-library.ts'),
+      'expo-speech': resolve(__dirname, './src/stubs/expo-speech.ts'),
     },
   },
   server: {


### PR DESCRIPTION
## Summary
- stub out React Native and Expo modules for web builds
- add placeholder `android/cordova-variables.gradle`
- update Capacitor build script after sync

## Testing
- `npm run build`
- `npx cap sync android`
- `npm test` *(fails: ReferenceError: module is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c734fe04832fbf8437f3ccceb97c