### PR TITLE
Exclude native packages from Vite build

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -2,8 +2,8 @@
 
 android {
   compileOptions {
-      sourceCompatibility JavaVersion.VERSION_17
-      targetCompatibility JavaVersion.VERSION_17
+      sourceCompatibility JavaVersion.VERSION_21
+      targetCompatibility JavaVersion.VERSION_21
   }
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,14 +20,38 @@ export default defineConfig({
     open: true
   },
   optimizeDeps: {
-    exclude: ['mongodb'] // Exclude MongoDB from browser bundling
+    // Exclude packages that rely on native modules or Node-specific APIs
+    exclude: [
+      'mongodb',
+      'react-native-ble-plx',
+      '@react-native-voice/voice',
+      'expo-av',
+      'expo-camera',
+      'expo-file-system',
+      'expo-media-library',
+      'expo-speech',
+      'react-native-health'
+    ]
   },
   build: {
     target: 'es2015',
     minify: 'esbuild',
     sourcemap: false,
     rollupOptions: {
-      external: ['mongodb', 'crypto', 'util'], // Mark as external for build
+      // Prevent bundling of Node-specific and native-only packages
+      external: [
+        'mongodb',
+        'crypto',
+        'util',
+        'react-native-ble-plx',
+        '@react-native-voice/voice',
+        'expo-av',
+        'expo-camera',
+        'expo-file-system',
+        'expo-media-library',
+        'expo-speech',
+        'react-native-health'
+      ],
       output: {
         manualChunks: {
           vendor: ['react', 'react-dom'],


### PR DESCRIPTION
## Summary
- avoid bundling native-only packages in Vite by excluding them and marking external
- update Android build target to Java 21 after syncing Capacitor

## Testing
- `npm test` *(fails: ReferenceError: module is not defined in ES module scope)*
- `npm run build`
- `npx cap sync android`
- `npx cap sync ios`


------
https://chatgpt.com/codex/tasks/task_e_68a3c730f700832fa5c93f810cd6ad32