### PR TITLE
chore: remove broken icon references

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta name="mobile-web-app-capable" content="yes">
-    <link rel="icon" type="image/svg+xml" href="/medical-icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>EasyMedPro - AI Healthcare Platform</title>
     
@@ -16,22 +15,6 @@
     <meta name="apple-mobile-web-app-title" content="EasyMedPro" />
     <meta name="application-name" content="EasyMedPro" />
     <meta name="msapplication-TileColor" content="#3B82F6" />
-    <meta name="msapplication-config" content="/browserconfig.xml" />
-    
-    <!-- Apple Touch Icons -->
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon-152x152.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-180x180.png" />
-    <link rel="apple-touch-icon" sizes="167x167" href="/apple-touch-icon-167x167.png" />
-    
-    <!-- Splash Screen Images for iOS -->
-    <link rel="apple-touch-startup-image" href="/apple-splash-2048-2732.jpg" sizes="2048x2732" />
-    <link rel="apple-touch-startup-image" href="/apple-splash-1668-2224.jpg" sizes="1668x2224" />
-    <link rel="apple-touch-startup-image" href="/apple-splash-1536-2048.jpg" sizes="1536x2048" />
-    <link rel="apple-touch-startup-image" href="/apple-splash-1125-2436.jpg" sizes="1125x2436" />
-    <link rel="apple-touch-startup-image" href="/apple-splash-1242-2208.jpg" sizes="1242x2208" />
-    <link rel="apple-touch-startup-image" href="/apple-splash-750-1334.jpg" sizes="750x1334" />
-    <link rel="apple-touch-startup-image" href="/apple-splash-828-1792.jpg" sizes="828x1792" />
     
     <!-- SEO and Description -->
     <meta name="description" content="EasyMedPro - Comprehensive AI-powered healthcare platform with multilingual support, IoT integration, genetic insights, and personalized wellness coaching." />
@@ -41,14 +24,12 @@
     <!-- Social Media Meta Tags -->
     <meta property="og:title" content="EasyMedPro - AI Healthcare Platform" />
     <meta property="og:description" content="Revolutionary healthcare platform with AI assistance, real-time monitoring, and personalized wellness coaching." />
-    <meta property="og:image" content="/og-image.png" />
     <meta property="og:url" content="https://easymedpro.com" />
     <meta property="og:type" content="website" />
     
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="EasyMedPro - AI Healthcare Platform" />
     <meta name="twitter:description" content="Revolutionary healthcare platform with AI assistance, real-time monitoring, and personalized wellness coaching." />
-    <meta name="twitter:image" content="/twitter-image.png" />
   </head>
   <body>
     <div id="root"></div>

--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta name="mobile-web-app-capable" content="yes">
-    <link rel="icon" type="image/svg+xml" href="/medical-icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>EasyMedPro - AI Healthcare Platform</title>
     
@@ -16,22 +15,6 @@
     <meta name="apple-mobile-web-app-title" content="EasyMedPro" />
     <meta name="application-name" content="EasyMedPro" />
     <meta name="msapplication-TileColor" content="#3B82F6" />
-    <meta name="msapplication-config" content="/browserconfig.xml" />
-    
-    <!-- Apple Touch Icons -->
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon-152x152.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-180x180.png" />
-    <link rel="apple-touch-icon" sizes="167x167" href="/apple-touch-icon-167x167.png" />
-    
-    <!-- Splash Screen Images for iOS -->
-    <link rel="apple-touch-startup-image" href="/apple-splash-2048-2732.jpg" sizes="2048x2732" />
-    <link rel="apple-touch-startup-image" href="/apple-splash-1668-2224.jpg" sizes="1668x2224" />
-    <link rel="apple-touch-startup-image" href="/apple-splash-1536-2048.jpg" sizes="1536x2048" />
-    <link rel="apple-touch-startup-image" href="/apple-splash-1125-2436.jpg" sizes="1125x2436" />
-    <link rel="apple-touch-startup-image" href="/apple-splash-1242-2208.jpg" sizes="1242x2208" />
-    <link rel="apple-touch-startup-image" href="/apple-splash-750-1334.jpg" sizes="750x1334" />
-    <link rel="apple-touch-startup-image" href="/apple-splash-828-1792.jpg" sizes="828x1792" />
     
     <!-- SEO and Description -->
     <meta name="description" content="EasyMedPro - Comprehensive AI-powered healthcare platform with multilingual support, IoT integration, genetic insights, and personalized wellness coaching." />
@@ -41,14 +24,12 @@
     <!-- Social Media Meta Tags -->
     <meta property="og:title" content="EasyMedPro - AI Healthcare Platform" />
     <meta property="og:description" content="Revolutionary healthcare platform with AI assistance, real-time monitoring, and personalized wellness coaching." />
-    <meta property="og:image" content="/og-image.png" />
     <meta property="og:url" content="https://easymedpro.com" />
     <meta property="og:type" content="website" />
     
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="EasyMedPro - AI Healthcare Platform" />
     <meta name="twitter:description" content="Revolutionary healthcare platform with AI assistance, real-time monitoring, and personalized wellness coaching." />
-    <meta name="twitter:image" content="/twitter-image.png" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- drop references to non-existent icons, splash screens, and social preview images

## Testing
- `npm test` *(fails: ReferenceError: module is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c68c6444832f8bfd3f30df3dc59c