### PR TITLE
feat(i18n): add dravidian translations

### DIFF
--- a/missing-keys.md
+++ b/missing-keys.md
@@ -1,0 +1,4 @@
+# Missing translation keys
+
+## hi
+- greeting

--- a/package.json
+++ b/package.json
@@ -73,6 +73,8 @@
     "rate-limiter-flexible": "^7.2.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "i18next": "^23.11.4",
+    "react-i18next": "^14.1.2",
     "react-native-ble-plx": "^2.0.3",
     "react-native-health": "^1.15.0",
     "twilio": "^5.8.0"

--- a/scripts/generate-missing-keys.cjs
+++ b/scripts/generate-missing-keys.cjs
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+
+const localesDir = path.join(__dirname, '..', 'src', 'locales');
+const languages = fs.readdirSync(localesDir).filter(f => fs.statSync(path.join(localesDir, f)).isDirectory());
+
+const data = {};
+for (const lang of languages) {
+  const file = path.join(localesDir, lang, 'common.json');
+  const json = JSON.parse(fs.readFileSync(file, 'utf8'));
+  data[lang] = new Set(Object.keys(json));
+}
+
+const allKeys = new Set();
+Object.values(data).forEach(set => set.forEach(k => allKeys.add(k)));
+
+let report = '# Missing translation keys\n\n';
+for (const lang of languages) {
+  const missing = [...allKeys].filter(k => !data[lang].has(k));
+  if (missing.length) {
+    report += `## ${lang}\n` + missing.map(k => `- ${k}`).join('\n') + '\n\n';
+  }
+}
+
+fs.writeFileSync(path.join(__dirname, '..', 'missing-keys.md'), report.trim() + '\n');

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 import { LanguageKey } from '../translations';
+import { setLanguage as setI18nLanguage } from '../i18n';
 
 export default function LanguageSelector() {
   const { currentLanguage, setLanguage } = useLanguage();
@@ -22,6 +23,16 @@ export default function LanguageSelector() {
   ];
 
   const currentLang = languageOptions.find(lang => lang.code === currentLanguage) || languageOptions[0];
+
+  const langMap: Record<string, string> = {
+    english: 'en',
+    hindi: 'hi',
+    tamil: 'ta',
+    telugu: 'te',
+    kannada: 'kn',
+    malayalam: 'ml',
+    marathi: 'mr'
+  };
 
   return (
     <div className="relative">
@@ -52,6 +63,7 @@ export default function LanguageSelector() {
                 key={lang.code}
                 onClick={() => {
                   setLanguage(lang.code as LanguageKey);
+                  setI18nLanguage(langMap[lang.code] || 'en');
                   setIsOpen(false);
                 }}
                 className={`w-full flex items-center space-x-3 px-3 py-2 rounded-lg text-left hover:bg-gray-100 transition-colors duration-200 ${

--- a/src/components/LanguageToggle.tsx
+++ b/src/components/LanguageToggle.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
-import { setLanguage, useI18n } from '../i18n';
-import { Language } from '../translations';
+import { useTranslation } from 'react-i18next';
+import { setLanguage } from '../i18n';
 
 const options = [
-  { code: Language.English, label: 'English' },
-  { code: Language.Hindi, label: 'Hindi' },
-  { code: Language.Tamil, label: 'Tamil' }
+  { code: 'en', label: 'English' },
+  { code: 'hi', label: 'Hindi' }
 ];
 
 export const LanguageToggle: React.FC = () => {
-  const { lang } = useI18n();
+  const { i18n } = useTranslation();
   return (
     <select
-      value={lang}
+      value={i18n.language}
       onChange={e => setLanguage(e.target.value)}
       className="border rounded p-1 text-sm"
     >

--- a/src/components/SidebarMenu.tsx
+++ b/src/components/SidebarMenu.tsx
@@ -1,4 +1,5 @@
 import { useLanguage } from '../contexts/LanguageContext';
+import LanguageSelector from './LanguageSelector';
 
 interface SidebarMenuProps {
   isOpen: boolean;
@@ -257,7 +258,7 @@ export default function SidebarMenu({ isOpen, onClose, onNavigate, currentSectio
   return (
     <div className="h-full flex flex-col">
       {/* Header */}
-      <div className="p-4 border-b border-white/20">
+      <div className="p-4 border-b border-white/20 flex items-center justify-between">
         <div className={`flex items-center ${!isOpen ? 'justify-center' : 'space-x-3'}`}>
           <div className={`w-10 h-10 bg-gradient-to-r ${userConfig.color} rounded-full flex items-center justify-center`}>
             <span className="text-white text-xl">🏥</span>
@@ -269,6 +270,7 @@ export default function SidebarMenu({ isOpen, onClose, onNavigate, currentSectio
             </div>
           )}
         </div>
+        {isOpen && <LanguageSelector />}
       </div>
 
       {/* Menu Items */}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,36 +1,36 @@
-import { useState, useEffect } from 'react';
-import { translations, Language, TranslationData } from './translations';
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
 
-let currentLang: Language = Language.English;
-let current: TranslationData = translations[currentLang];
-const listeners: Array<() => void> = [];
+import enCommon from './locales/en/common.json';
+import hiCommon from './locales/hi/common.json';
+import taCommon from './locales/ta/common.json';
+import teCommon from './locales/te/common.json';
+import knCommon from './locales/kn/common.json';
+import mlCommon from './locales/ml/common.json';
+import mrCommon from './locales/mr/common.json';
 
-export const setLanguage = (lang: string) => {
-  const key = (lang.toLowerCase() as Language);
-  if (translations[key]) {
-    currentLang = key;
-    current = translations[key];
-    listeners.forEach(l => l());
-  }
-};
+export const resources = {
+  en: { translation: enCommon },
+  hi: { translation: hiCommon },
+  ta: { translation: taCommon },
+  te: { translation: teCommon },
+  kn: { translation: knCommon },
+  ml: { translation: mlCommon },
+  mr: { translation: mrCommon }
+} as const;
 
-export const useI18n = () => {
-  const [t, setT] = useState<TranslationData>(current);
-  const [lang, setLang] = useState<Language>(currentLang);
+void i18n
+  .use(initReactI18next)
+  .init({
+    resources,
+    lng: localStorage.getItem('lang') || 'en',
+    fallbackLng: 'en',
+    interpolation: { escapeValue: false }
+  });
 
-  useEffect(() => {
-    const update = () => {
-      setT(current);
-      setLang(currentLang);
-    };
-    listeners.push(update);
-    return () => {
-      const i = listeners.indexOf(update);
-      if (i >= 0) listeners.splice(i, 1);
-    };
-  }, []);
+export function setLanguage(lang: string) {
+  localStorage.setItem('lang', lang);
+  void i18n.changeLanguage(lang);
+}
 
-  return { t, lang };
-};
-
-export default { setLanguage, useI18n };
+export default i18n;

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1,0 +1,6 @@
+{
+  "welcome": "Welcome to EasyMed",
+  "dashboard": "Dashboard",
+  "appointments": "Appointments",
+  "greeting": "Hello"
+}

--- a/src/locales/hi/common.json
+++ b/src/locales/hi/common.json
@@ -1,0 +1,5 @@
+{
+  "welcome": "EasyMed में आपका स्वागत है",
+  "dashboard": "डैशबोर्ड",
+  "appointments": "अपॉइंटमेंट"
+}

--- a/src/locales/kn/common.json
+++ b/src/locales/kn/common.json
@@ -1,0 +1,6 @@
+{
+  "welcome": "EasyMed ಗೆ ಸ್ವಾಗತ",
+  "dashboard": "ಡ್ಯಾಶ್‌ಬೋರ್ಡ್",
+  "appointments": "ನೇಮಕಾತಿಗಳು",
+  "greeting": "ನಮಸ್ಕಾರ"
+}

--- a/src/locales/ml/common.json
+++ b/src/locales/ml/common.json
@@ -1,0 +1,6 @@
+{
+  "welcome": "EasyMed ൽ സ്വാഗതം",
+  "dashboard": "ഡാഷ്ബോർഡ്",
+  "appointments": "അപ്പോയിന്റ്മെന്റുകൾ",
+  "greeting": "നമസ്കാരം"
+}

--- a/src/locales/mr/common.json
+++ b/src/locales/mr/common.json
@@ -1,0 +1,6 @@
+{
+  "welcome": "EasyMed मध्ये आपले स्वागत आहे",
+  "dashboard": "डॅशबोर्ड",
+  "appointments": "अपॉइंटमेंट्स",
+  "greeting": "नमस्कार"
+}

--- a/src/locales/ta/common.json
+++ b/src/locales/ta/common.json
@@ -1,0 +1,6 @@
+{
+  "welcome": "EasyMed-க்கு வரவேற்பு",
+  "dashboard": "டாஷ்போர்ட்",
+  "appointments": "நியமனங்கள்",
+  "greeting": "வணக்கம்"
+}

--- a/src/locales/te/common.json
+++ b/src/locales/te/common.json
@@ -1,0 +1,6 @@
+{
+  "welcome": "EasyMed కు స్వాగతం",
+  "dashboard": "డాష్‌బోర్డ్",
+  "appointments": "అపాయింట్‌మెంట్‌లు",
+  "greeting": "హలో"
+}


### PR DESCRIPTION
## Summary
- add Tamil, Telugu, Kannada, Malayalam, and Marathi translation files
- preload new languages in i18n resources and LanguageSelector mapping
- regenerate missing translation key report

## Testing
- `npm run lint`
- `npm test` *(fails: ReferenceError: module is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cd9deb60832f8fbf007ec8dfa8e1