### PR TITLE
Add tests for OTP, chart resizing, and i18n persistence

### DIFF
--- a/src/__tests__/chart.test.tsx
+++ b/src/__tests__/chart.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import useResizeObserver from '../hooks/useResizeObserver';
+
+jest.mock('@capacitor/app', () => ({
+  App: { addListener: jest.fn().mockReturnValue({ remove: jest.fn() }) }
+}));
+
+describe('Chart resizing', () => {
+  it('invokes resize on container size change', () => {
+    let observerCallback: () => void = () => {};
+    (global as any).ResizeObserver = class {
+      constructor(cb: () => void) { observerCallback = cb; }
+      observe() {}
+      disconnect() {}
+    };
+
+    const resize = jest.fn();
+
+    const Chart = () => {
+      const ref = React.useRef<HTMLDivElement>(null);
+      const chart = React.useRef({ resize });
+      useResizeObserver(ref, () => chart.current.resize());
+      return <div ref={ref}></div>;
+    };
+
+    const container = document.createElement('div');
+    act(() => {
+      createRoot(container).render(<Chart />);
+    });
+
+    act(() => { observerCallback(); });
+
+    expect(resize).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/i18n.test.ts
+++ b/src/__tests__/i18n.test.ts
@@ -1,0 +1,36 @@
+const mockStorage = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: jest.fn((key: string) => store[key]),
+    setItem: jest.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    clear: jest.fn(() => { store = {}; })
+  } as Storage;
+})();
+
+Object.defineProperty(window, 'localStorage', { value: mockStorage });
+
+async function importI18n() {
+  const mod = await import('../i18n');
+  await new Promise(resolve => setTimeout(resolve, 0));
+  return mod;
+}
+
+describe('i18n persistence', () => {
+  beforeEach(() => {
+    mockStorage.clear();
+    jest.resetModules();
+  });
+
+  it('persists language selection across reloads', async () => {
+    let i18nModule = await importI18n();
+    i18nModule.setLanguage('hi');
+    expect(mockStorage.setItem).toHaveBeenCalledWith('lang', 'hi');
+
+    jest.resetModules();
+    i18nModule = await importI18n();
+    expect(mockStorage.getItem).toHaveBeenCalledWith('lang');
+    expect(i18nModule.default.language).toBe('hi');
+  });
+});

--- a/src/__tests__/otp.test.ts
+++ b/src/__tests__/otp.test.ts
@@ -1,0 +1,34 @@
+import { sendOtp, verifyOtp } from '../utils/otp';
+
+describe('OTP flow', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.resetAllMocks();
+  });
+
+  it('sends and verifies OTP successfully', async () => {
+    const fetchMock = jest.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ sent: true }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ verified: true }) });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const sendResponse = await sendOtp('1234567890');
+    const verifyResponse = await verifyOtp('1234567890', '1234');
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      '/api/sms/send-otp',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(sendResponse).toEqual({ sent: true });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      '/api/sms/verify-otp',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(verifyResponse).toEqual({ verified: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add OTP flow happy-path test using mocked fetch
- ensure chart components trigger resize on container changes
- verify language toggle persists through reload with localStorage mock

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden @capacitor-community/speech-recognition)*

------
https://chatgpt.com/codex/tasks/task_e_68a590330230832f9fa0c1d97e748ee9