### PR TITLE
Add permission and partial result handling to voice hook

### DIFF
--- a/src/hooks/useVoice.ts
+++ b/src/hooks/useVoice.ts
@@ -1,17 +1,53 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { SpeechRecognition } from '@capacitor-community/speech-recognition';
 import { TextToSpeech } from '@capacitor-community/text-to-speech';
 
 export function useVoice() {
   const [listening, setListening] = useState(false);
+  const [transcript, setTranscript] = useState('');
+  const permissionRequested = useRef(false);
+
+  useEffect(() => {
+    // Listen for partial speech recognition results
+    const partialListener = SpeechRecognition.addListener('partialResults', ({ value }) => {
+      if (Array.isArray(value)) {
+        setTranscript(value.join(' '));
+      } else if (typeof value === 'string') {
+        setTranscript(value);
+      }
+    });
+
+    return () => {
+      partialListener.remove();
+    };
+  }, []);
 
   const speak = async (text: string, lang: string = 'en-US') => {
     await TextToSpeech.speak({ text, lang, rate: 1.0 });
   };
 
+  const ensurePermission = async () => {
+    if (!permissionRequested.current) {
+      await SpeechRecognition.requestPermission();
+      permissionRequested.current = true;
+    }
+    return SpeechRecognition.hasPermission();
+  };
+
   const start = async (lang: string = 'en-US') => {
+    const hasPermission = await ensurePermission();
+    if (!hasPermission) {
+      return [];
+    }
+
+    setTranscript('');
     setListening(true);
-    const { value } = await SpeechRecognition.start({ language: lang, popup: false });
+    const { value } = await SpeechRecognition.start({ language: lang, popup: false, partialResults: true });
+    if (Array.isArray(value)) {
+      setTranscript(value.join(' '));
+    } else if (typeof value === 'string') {
+      setTranscript(value);
+    }
     return value;
   };
 
@@ -20,7 +56,7 @@ export function useVoice() {
     setListening(false);
   };
 
-  return { listening, start, stop, speak };
+  return { listening, transcript, start, stop, speak };
 }
 
 export default useVoice;


### PR DESCRIPTION
## Summary
- request speech recognition permission before starting
- add partial result listener to update live transcript

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install --no-audit --no-fund jest@29 @types/jest@29 ts-jest@29` *(fails: No matching version found for @capacitor-community/speech-recognition@^4.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a59031e5c0832fb58267dc607a8201