### PR TITLE
Add Hindi greeting translation

### DIFF
--- a/missing-keys.md
+++ b/missing-keys.md
@@ -1,4 +1,1 @@
 # Missing translation keys
-
-## hi
-- greeting

--- a/src/locales/hi/common.json
+++ b/src/locales/hi/common.json
@@ -1,5 +1,6 @@
 {
   "welcome": "EasyMed में आपका स्वागत है",
   "dashboard": "डैशबोर्ड",
-  "appointments": "अपॉइंटमेंट"
+  "appointments": "अपॉइंटमेंट",
+  "greeting": "नमस्ते"
 }


### PR DESCRIPTION
## Summary
- add Hindi translation for greeting
- regenerate missing translation keys

## Testing
- `npm run lint`
- `npm install` *(fails: No matching version found for @capacitor-community/speech-recognition@^4.1.0)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a590305eb4832fbd31f00a8396bbb3