### PR TITLE
feat: configure API base and document env vars

### DIFF
--- a/ENV.md
+++ b/ENV.md
@@ -1,0 +1,46 @@
+# Environment Variables
+
+This project uses Vite and Capacitor. The following environment variables configure client-side behavior.
+
+## API
+
+- **VITE_API_BASE**: Base URL for API requests. Defaults to `/api` when not set.
+
+## Firebase
+
+Provide the Firebase config for your project:
+
+- **VITE_FIREBASE_API_KEY**
+- **VITE_FIREBASE_AUTH_DOMAIN**
+- **VITE_FIREBASE_PROJECT_ID**
+- **VITE_FIREBASE_STORAGE_BUCKET**
+- **VITE_FIREBASE_MESSAGING_SENDER_ID**
+- **VITE_FIREBASE_APP_ID**
+- **VITE_FIREBASE_MEASUREMENT_ID**
+
+## Twilio (SMS/OTP)
+
+- **VITE_TWILIO_ACCOUNT_SID**
+- **VITE_TWILIO_AUTH_TOKEN**
+- **VITE_TWILIO_PHONE_NUMBER**
+
+## ABHA Integration
+
+- **VITE_ABHA_CLIENT_ID**
+- **VITE_ABHA_CLIENT_SECRET**
+
+## AI Services
+
+- **VITE_OPENAI_API_KEY**
+- **VITE_AI4BHARAT_API_KEY**
+
+## Other Keys
+
+- **VITE_MONGODB_URI** – MongoDB connection string
+- **VITE_GOOGLE_MAPS_API_KEY**
+- **VITE_FCM_VAPID_KEY**
+- **VITE_FCM_SERVER_KEY**
+- **VITE_JWT_SECRET**
+- **VITE_ENCRYPTION_KEY**
+
+Add these variables to an `.env` file or your deployment environment as needed.

--- a/packages/core/src/services/authService.ts
+++ b/packages/core/src/services/authService.ts
@@ -6,7 +6,8 @@
 import firebaseAuthService from './firebaseAuthService';
 import { storage } from '../storage';
 
-const API_BASE_URL = '/api';
+// Base URL for API requests, configurable via environment variable
+const API_BASE_URL = import.meta.env.VITE_API_BASE || '/api';
 
 class AuthenticationService {
   constructor() {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
+  readonly VITE_API_BASE: string
   readonly VITE_ABHA_BASE_URL: string
   readonly VITE_ABHA_CLIENT_ID: string
   readonly VITE_ABHA_CLIENT_SECRET: string


### PR DESCRIPTION
## Summary
- read API base URL from `VITE_API_BASE`
- declare `VITE_API_BASE` in env typings
- add `ENV.md` with environment variable documentation

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5902e750c832f998ce4c2a32525c4