### PR TITLE
Add main-screen wrapper to login page

### DIFF
--- a/src/components/LoginPage.tsx
+++ b/src/components/LoginPage.tsx
@@ -504,7 +504,7 @@ export default function LoginPage({ onLogin }: LoginPageProps) {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 flex items-center justify-center p-4">
+    <div className="main-screen min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 flex items-center justify-center p-4">
       {/* Hidden reCAPTCHA container for Firebase phone auth */}
       <div id="recaptcha-container" style={{ display: 'none' }}></div>
       


### PR DESCRIPTION
## Summary
- ensure LoginPage root container uses `main-screen` class for mobile safe-area padding

## Testing
- `npm test` *(fails: jest not found, install attempt missing @capacitor-community/speech-recognition@^4.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a59025d84c832f962990e5f2dd945e