### PR TITLE
chore: add start script and docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@
 FROM node:18-alpine
 WORKDIR /app
 COPY package*.json ./
-RUN npm install --production
+RUN npm install
 COPY . .
-EXPOSE 3000
+RUN npm run build
+EXPOSE 5000
 CMD ["npm", "start"]

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "packages/*"
   ],
   "scripts": {
+    "start": "node server/app.js",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",


### PR DESCRIPTION
## Summary
- add start script to run server/app.js
- build project before starting in Dockerfile and expose correct port

## Testing
- `npm test` *(fails: jest not found / missing package)*
- `npm ci` *(fails: no matching version for @capacitor-community/speech-recognition)*
- `docker build -t easymedpro-test .` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a670217200832f9c466d0c35ac1623