### PR TITLE
feat: add workbox service worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && cp public/sw.js dist/",
     "preview": "vite preview",
     "firebase:deploy": "npm run build && firebase deploy",
     "firebase:hosting": "npm run build && firebase deploy --only hosting",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,2 +1,37 @@
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.5.4/workbox-sw.js');
+
 self.addEventListener('install', () => self.skipWaiting());
-self.addEventListener('activate', e => e.waitUntil(self.clients.claim()));
+self.addEventListener('activate', event => event.waitUntil(self.clients.claim()));
+
+// Precache core assets.
+workbox.precaching.precacheAndRoute([
+  {url: '/', revision: null},
+  {url: '/index.html', revision: null},
+  {url: '/manifest.json', revision: null},
+  {url: '/offline.html', revision: null}
+]);
+
+// Provide offline fallback for navigation requests.
+workbox.routing.setCatchHandler(async ({event}) => {
+  if (event.request.mode === 'navigate') {
+    return caches.match('offline.html', {ignoreSearch: true});
+  }
+  return Response.error();
+});
+
+// Runtime caching for images.
+workbox.routing.registerRoute(
+  ({request}) => request.destination === 'image',
+  new workbox.strategies.StaleWhileRevalidate({
+    cacheName: 'images'
+  })
+);
+
+// Runtime caching for same-origin pages and assets.
+workbox.routing.registerRoute(
+  ({request, url}) => url.origin === self.location.origin &&
+    ['document', 'script', 'style'].includes(request.destination),
+  new workbox.strategies.NetworkFirst({
+    cacheName: 'assets'
+  })
+);


### PR DESCRIPTION
## Summary
- add Workbox-based service worker with precache and runtime caching
- ensure service worker copied during build

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a670333140832faa47125badeb19a5