### PR TITLE
Add route wrapper pages for dashboard navigation

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,15 +2,22 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import { ABHAProvider } from './contexts/ABHAContext'
+import { AdminProvider } from './contexts/AdminContext'
+import { LanguageProvider } from './contexts/LanguageContext'
 import './index.css'
+import './i18n'
 import { liveUpdateService } from './services/liveUpdateService'
 import { taskScheduler } from './services/taskScheduler'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   // <React.StrictMode> - Temporarily disabled for debugging
-    <ABHAProvider>
-      <App />
-    </ABHAProvider>
+    <LanguageProvider>
+      <AdminProvider>
+        <ABHAProvider>
+          <App />
+        </ABHAProvider>
+      </AdminProvider>
+    </LanguageProvider>
   // </React.StrictMode>,
 )
 

--- a/src/pages/admin/AdminDashboard.tsx
+++ b/src/pages/admin/AdminDashboard.tsx
@@ -1,0 +1,4 @@
+import Dashboard from '../Dashboard';
+
+// Wrapper for admin dashboard route (reuses main dashboard layout)
+export default Dashboard;

--- a/src/pages/asha/ASHAWorkerHub.tsx
+++ b/src/pages/asha/ASHAWorkerHub.tsx
@@ -1,0 +1,6 @@
+import ASHAWorkerHub from '@/components/ASHAWorkerHub';
+
+// Wrapper for ASHA worker hub route
+export default function ASHAWorkerHubPage() {
+  return <ASHAWorkerHub />;
+}

--- a/src/pages/doctor/DoctorDashboard.tsx
+++ b/src/pages/doctor/DoctorDashboard.tsx
@@ -1,0 +1,4 @@
+import Dashboard from '../Dashboard';
+
+// Wrapper for doctor dashboard route
+export default Dashboard;

--- a/src/pages/patient/PatientDashboard.tsx
+++ b/src/pages/patient/PatientDashboard.tsx
@@ -1,0 +1,4 @@
+import PatientDashboard from '../PatientDashboard';
+
+// Wrapper for patient dashboard route
+export default PatientDashboard;


### PR DESCRIPTION
## Summary
- add wrapper pages under `src/pages` to match dashboard route imports for patient, doctor, admin, and ASHA views
- ensure ASHA worker hub is exposed through a page component for routing compatibility

## Testing
- not run (Node/npm not available in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69336b6fdddc832fabff50d8a59ca804)